### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://petolu.visualstudio.com/f33ef650-6383-4e8e-87cd-61c87729ad49/697aa34c-4e00-4dd1-a356-e322cfa47fe3/_apis/work/boardbadge/da1b6841-a226-4a35-b3e0-b60c3e3c033d)](https://petolu.visualstudio.com/f33ef650-6383-4e8e-87cd-61c87729ad49/_boards/board/t/697aa34c-4e00-4dd1-a356-e322cfa47fe3/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#74](https://petolu.visualstudio.com/f33ef650-6383-4e8e-87cd-61c87729ad49/_workitems/edit/74). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.